### PR TITLE
Fix memory.js start after DOM loaded

### DIFF
--- a/memory.js
+++ b/memory.js
@@ -117,6 +117,8 @@ function triggerConfetti() {
   }
 }
 
-if (board && overlay) {
-  startGame();
-}
+document.addEventListener('DOMContentLoaded', () => {
+  if (board && overlay) {
+    startGame();
+  }
+});


### PR DESCRIPTION
## Summary
- trigger `startGame()` only after `DOMContentLoaded` event

## Testing
- `npm test` *(fails: could not find package.json)*